### PR TITLE
[#27] 필터링 api 응답에 필요한 프로퍼티 추가

### DIFF
--- a/BE/src/main/java/com/codesquad/airbnb/business/FilterService.java
+++ b/BE/src/main/java/com/codesquad/airbnb/business/FilterService.java
@@ -2,7 +2,6 @@ package com.codesquad.airbnb.business;
 
 import com.codesquad.airbnb.dao.AccommodationDAO;
 import com.codesquad.airbnb.domain.dto.AccommodationDTO;
-import com.codesquad.airbnb.domain.model.Accommodation;
 import com.codesquad.airbnb.domain.model.Filter;
 import com.codesquad.airbnb.util.CurrencyConvertor;
 import org.slf4j.Logger;
@@ -10,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -30,7 +28,7 @@ public class FilterService {
         Map<String, Object> parameters = createParameters(filter);
         Map<String, Object> result = new HashMap<>();
 
-        result.put("accommodations", findUsingFilter(parameters)
+        result.put("accommodations", accommodationDAO.findUsingFilter(parameters)
                 .stream()
                 .map(model -> new AccommodationDTO.Builder(model.getId())
                         .name(model.getName())
@@ -46,11 +44,6 @@ public class FilterService {
         result.put("total", accommodationDAO.countOfFilterResult(parameters));
 
         return result;
-    }
-
-    // 테스트 코드를 위해서 메소드로 분리
-    public List<Accommodation> findUsingFilter(Map<String, Object> parameters) {
-        return accommodationDAO.findUsingFilter(parameters);
     }
 
     private Map<String, Object> createParameters(Filter filter) {

--- a/BE/src/main/java/com/codesquad/airbnb/dao/AccommodationDAO.java
+++ b/BE/src/main/java/com/codesquad/airbnb/dao/AccommodationDAO.java
@@ -5,7 +5,6 @@ import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -17,18 +16,11 @@ public class AccommodationDAO {
     @Autowired
     private SqlSession sqlSession;
 
-    public List<Accommodation> findUsingFilter(int people,
-                                               int priceMin, int priceMax,
-                                               float exchangeRate,
-                                               long period,
-                                               int itemsOffset) {
-        Map<String, Object> parameters = new HashMap<>();
-        parameters.put("people", people);
-        parameters.put("priceMin", priceMin);
-        parameters.put("priceMax", priceMax);
-        parameters.put("exchangeRate", exchangeRate);
-        parameters.put("period", period);
-        parameters.put("itemsOffset", itemsOffset);
+    public List<Accommodation> findUsingFilter(Map<String, Object> parameters) {
         return sqlSession.selectList(NAMESPACE + "findUsingFilter", parameters);
+    }
+
+    public int countOfFilterResult(Map<String, Object> parameters) {
+        return sqlSession.selectOne(NAMESPACE + "countOfFilterResult", parameters);
     }
 }

--- a/BE/src/main/resources/mapper/mapper.xml
+++ b/BE/src/main/resources/mapper/mapper.xml
@@ -159,4 +159,37 @@
             <result column="image_url"/>
         </collection>
     </resultMap>
+    <select id="countOfFilterResult" resultType="int">
+        SELECT  COUNT(price)
+        FROM    accommodation a
+        LEFT OUTER JOIN
+        (SELECT id,
+                TRUNCATE((price - price * discount_rate), 2) as price_discounted,
+                TRUNCATE((price - price * discount_rate) * (1 - ((price - price * discount_rate) -
+        (SELECT MIN(price)
+        FROM    accommodation)) /
+        (SELECT MAX(price) - MIN(price)
+        FROM    accommodation)) *
+        (SELECT service_max
+        FROM    fee_policy), 2) as service_tax
+        FROM    accommodation) temp
+        ON a.id = temp.id
+        <where>
+            minimum_nights <![CDATA[<=]]> #{period}
+            AND maximum_nights >= #{period}
+            <if test="people != 0">
+                AND     maximum_capacity >= #{people}
+            </if>
+            <if test="priceMin != 0">
+                AND     TRUNCATE(price_discounted + service_tax + service_tax *
+                (SELECT accommodation_tax
+                FROM fee_policy) + cleaning_fee, 2) * ${exchangeRate} >= #{priceMin}
+            </if>
+            <if test="priceMin != 0">
+                AND     TRUNCATE(price_discounted + service_tax + service_tax *
+                (SELECT accommodation_tax
+                FROM fee_policy) + cleaning_fee, 2) * ${exchangeRate} <![CDATA[<=]]> #{priceMax}
+            </if>
+        </where>
+    </select>
 </mapper>

--- a/BE/src/test/java/com/codesquad/airbnb/dao/AccommodationDAOTest.java
+++ b/BE/src/test/java/com/codesquad/airbnb/dao/AccommodationDAOTest.java
@@ -1,8 +1,9 @@
-package com.codesquad.airbnb.business;
+package com.codesquad.airbnb.dao;
 
 import com.codesquad.airbnb.domain.model.Accommodation;
 import com.codesquad.airbnb.domain.model.Filter;
 import com.codesquad.airbnb.util.CurrencyConvertor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,21 +11,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class FilterServiceTest {
+public class AccommodationDAOTest {
 
-    private static final Logger log = LoggerFactory.getLogger(FilterServiceTest.class);
+    private static final Logger log = LoggerFactory.getLogger(AccommodationDAOTest.class);
 
     @Autowired
-    private FilterService filterService;
+    private AccommodationDAO accommodationDAO;
 
-    @Test
-    public void 숙소_필터링() throws Exception {
+    private Filter filter;
+    private Map<String, Object> parameters;
+
+    @BeforeEach
+    public void setParameters() {
         // given
-        Filter filter = new Filter();
+        filter = new Filter();
         // 1. 날짜 조건
         filter.setCheckIn(LocalDate.parse("2020-05-23"));
         filter.setCheckOut(LocalDate.parse("2020-05-24"));
@@ -37,8 +44,19 @@ public class FilterServiceTest {
         // 4. 페이징
         filter.setItemsOffset(0);
 
+        parameters = new HashMap<>();
+        parameters.put("people", filter.getPeople());
+        parameters.put("priceMin", filter.getPriceMin());
+        parameters.put("priceMax", filter.getPriceMax());
+        parameters.put("exchangeRate", CurrencyConvertor.EXCHANGE_RATE_FROM_USD_TO_KRW);
+        parameters.put("period", filter.getPeriod());
+        parameters.put("itemsOffset", filter.getItemsOffset());
+    }
+
+    @Test
+    public void 숙소_필터링() throws Exception {
         // when
-        List<Accommodation> accommodations = filterService.findUsingFilter(filter);
+        List<Accommodation> accommodations = accommodationDAO.findUsingFilter(parameters);
 
         // then
         assertThat(accommodations).isNotNull();
@@ -49,6 +67,15 @@ public class FilterServiceTest {
         // 인원 검사
         assertThat(accommodations).allMatch(a -> a.getMaximumCapacity() >= filter.getPeople());
         // 페이징 검사
-        assertThat(accommodations.size()).isEqualTo(4);
+        assertThat(accommodations.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void 숙소_필터링_총_개수() throws Exception {
+        // when
+        int total = accommodationDAO.countOfFilterResult(parameters);
+
+        // then
+        assertThat(total).isEqualTo(2);
     }
 }


### PR DESCRIPTION
#2 참고

### 구현한 기능
- 필터링 api 응답에 숙소 리스트를 포함하여 필터링된 숙소의 총 개수를 나타내는 `total` 프로퍼티 추가
- `total` 값을 구하기 위하여 필터링된 숙소의 총 개수를 반환하는 쿼리 구현
- 기존 테스트 코드(`FilterServiceTest`)에서 비즈니스 로직과 관련된 테스트 코드보다는 쿼리 결과에 대한 테스트 코드가 많기 때문에 `AccommodationDAOTest`로 변경함
